### PR TITLE
Feat/#67 온보딩 및 홈 뷰 UI 수정

### DIFF
--- a/TIG/TIG/Constant/AppColor.swift
+++ b/TIG/TIG/Constant/AppColor.swift
@@ -15,6 +15,8 @@ struct AppColor {
   static let gray03 = Color(.gray03)
   static let gray04 = Color(.gray04)
   static let gray05 = Color(.gray05)
+    
+  static let timerGray = Color(.timerGray)
   
   static let darkWhite = Color(.darkWhite)
   static let darkOnboarding = Color(.darkOnboarding)

--- a/TIG/TIG/Extension/Int+Ext.swift
+++ b/TIG/TIG/Extension/Int+Ext.swift
@@ -34,7 +34,7 @@ extension Int {
   func formattedTime() -> String {
     let hours = self / 60
     let minutes = (self % 60)/* / 60*/
-    return String(format: "%01d시간 %02d분", hours, minutes)
+    return String(format: "%01d시간 %01d분", hours, minutes)
   }
   
   /// 0..<48 범위에 존재하는 값을 시간으로 변환

--- a/TIG/TIG/Feature/Home/Timer/TimerView.swift
+++ b/TIG/TIG/Feature/Home/Timer/TimerView.swift
@@ -126,7 +126,7 @@ fileprivate struct TimerTrack: View {
         Circle()
             .fill(Color.clear)
             .overlay(
-                Circle().stroke(AppColor.darkWhite, lineWidth: 12)
+                Circle().stroke(AppColor.darkWhite, lineWidth: 13)
             )
             .padding(.horizontal, 4)
         
@@ -143,8 +143,8 @@ fileprivate struct TimerProgressBar: View {
             .trim(from: progress, to: 1)
             .stroke(
                 style: StrokeStyle(
-                    lineWidth: 16,
-                    lineCap: .round,
+                    lineWidth: 13,
+                    lineCap: .square,
                     lineJoin: .round
                 )
             )

--- a/TIG/TIG/Feature/Home/Timer/TimerView.swift
+++ b/TIG/TIG/Feature/Home/Timer/TimerView.swift
@@ -126,7 +126,7 @@ fileprivate struct TimerTrack: View {
         Circle()
             .fill(Color.clear)
             .overlay(
-                Circle().stroke(AppColor.darkWhite, lineWidth: 13)
+                Circle().stroke(AppColor.timerGray, lineWidth: 13)
             )
             .padding(.horizontal, 4)
         

--- a/TIG/TIG/Feature/Onboarding/OnboardingView.swift
+++ b/TIG/TIG/Feature/Onboarding/OnboardingView.swift
@@ -181,8 +181,9 @@ fileprivate struct SleepTimeSettingView: View {
       Text("수면 시간을 제외한 활용 가능 시간을 알려드릴게요\n설정에서 언제든지 변경할 수 있습니다")
         .font(.custom(AppFont.regular, size: 14))
         .multilineTextAlignment(.center)
-        .foregroundStyle(AppColor.gray04)
+        .foregroundStyle(AppColor.gray03)
         .padding(.top, 12)
+        .lineSpacing(6)
       
       Spacer()
         .frame(height: 30)

--- a/TIG/TIG/Resource/Colors.xcassets/timerGray.colorset/Contents.json
+++ b/TIG/TIG/Resource/Colors.xcassets/timerGray.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xEA",
-          "green" : "0xE5",
-          "red" : "0xE5"
+          "blue" : "0xDF",
+          "green" : "0xD3",
+          "red" : "0xD3"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x2C",
-          "green" : "0x2A",
-          "red" : "0x2A"
+          "blue" : "0x3A",
+          "green" : "0x38",
+          "red" : "0x38"
         }
       },
       "idiom" : "universal"

--- a/TIG/TIG/Resource/Colors.xcassets/timerGray.colorset/Contents.json
+++ b/TIG/TIG/Resource/Colors.xcassets/timerGray.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xEA",
+          "green" : "0xE5",
+          "red" : "0xE5"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x2C",
+          "green" : "0x2A",
+          "red" : "0x2A"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #67 

## 📝 작업 내용

온보딩 뷰 수면 시간 설정 뷰의 텍스트 크기와 행간을 수정했습니다.
타이머 뷰의 시간 표현 방식과 타이머 색상 및 크기 수정했습니다.

## 💬 리뷰 요구사항

수정된 타이머 배경 색 우선은 'timerGray'로 추가해서 올려뒀습니다.