### PR TITLE
Fix/#70 타임라인 버그 수정

### DIFF
--- a/TIG/TIG/Feature/Home/HomeViewModel.swift
+++ b/TIG/TIG/Feature/Home/HomeViewModel.swift
@@ -86,6 +86,7 @@ final class HomeViewModel {
     case .calendarTapped:
       self.state.isCalendarVisible.toggle()
     case .dateTapped(let date):
+      self.state.isEditMode = false
       self.state.currentDate = date
       self.state.isCalendarVisible = false
       self.state.dailyContent = readDailyContent(date)

--- a/TIG/TIG/Feature/Home/Timeline/TimelineView.swift
+++ b/TIG/TIG/Feature/Home/Timeline/TimelineView.swift
@@ -184,7 +184,7 @@ fileprivate struct TimeMarkerView: View {
           Spacer().frame(width: 14, height: 39)
           
           Rectangle()
-            .frame(width: index % 2 == 0 ? 28 : 16, height: 1)
+            .frame(width: isHour ? 28 : 16, height: 1)
             .foregroundStyle(AppColor.gray02)
         }
         


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #70 

## 📝 작업 내용
타임라인 버그를 수정하였습니다.
- 타임라인 시간표시 부분에서 30분 부터 시작 시 긴선부터 표시되는 버그 수정
- 편집시에 다른 날짜로 이동하면 편집상태가 유지되는 버그 수정

## 💬 리뷰 요구사항(선택)
없습니다.